### PR TITLE
rendering getting transform attached to entity

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -10,7 +10,7 @@
 #include "Renderer.hpp"
 
 void UpdateTransform(float deltaTime);
-Registry<Transform> g_reg;
+Registry<Transform, Renderable> g_reg;
 
 int main()
 {
@@ -24,17 +24,22 @@ int main()
     try
     {
         std::cout << "\033[2J";
-        renderer.init();
         // should make a time class for all these
         uint32_t tea1 = g_reg.addEntity();
         Transform tea1_transform = {{0,-2,0}, {1,1,1}, {1,1,1}};
+        Renderable tea1_renderable = {"resources/teapot.obj"};
         g_reg.addComponent(tea1, tea1_transform);
+        g_reg.addComponent(tea1, tea1_renderable);
+
 
         uint32_t tea2 = g_reg.addEntity();
         Transform tea2_transform = {{0,2,0}, {1,1,1}, {1,1,1}};
+        Renderable tea2_renderable = {"resources/teapot.obj"};
         g_reg.addComponent(tea2, tea2_transform);
-        const auto startTime = std::chrono::high_resolution_clock::now();
+        g_reg.addComponent(tea2, tea2_renderable);
 
+        renderer.init();
+        const auto startTime = std::chrono::high_resolution_clock::now();
         std::cout << Logger::info << "Main loop" << Logger::reset;
         auto last = std::chrono::high_resolution_clock::now();
         while (!glfwWindowShouldClose(Window::win))

--- a/src/ecs/Components.hpp
+++ b/src/ecs/Components.hpp
@@ -1,12 +1,17 @@
 #ifndef DEFAULT_COMPONENTS
 #define DEFAULT_COMPONENTS
 
+#include <memory>
 #include <glm/glm.hpp>
 
 struct Transform {
     glm::vec3 pos;
     glm::vec3 scale;
     glm::vec3 rotation;
+};
+
+struct Renderable {
+    std::string model_name;
 };
 
 #endif

--- a/src/ecs/Register.hpp
+++ b/src/ecs/Register.hpp
@@ -69,7 +69,7 @@ public:
         return res;
     }
     template <typename cp>
-    cp& getComponent(entity_id entity)
+    cp getComponent(entity_id entity)
     {
         std::vector<component_id> ids = _entities[entity];
 
@@ -78,7 +78,7 @@ public:
             auto current = _components[id];
             try
             {
-                cp& res = std::get<cp>(current);
+                cp res = std::get<cp>(current);
                 return res;
             }
             catch (const std::exception &e)

--- a/src/ecs/Register.hpp
+++ b/src/ecs/Register.hpp
@@ -44,6 +44,7 @@ public:
             ids[i] = fitting[i].second;
         return ids;
     }
+
     template <typename cp>
     std::vector<component_id> getComponentIds()
     {
@@ -113,6 +114,6 @@ private:
 };
 
 // ADD ALL COMPONENTS HERE
-extern Registry<Transform> g_reg;
+extern Registry<Transform, Renderable> g_reg;
 
 #endif

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -5,8 +5,8 @@
 #include <iostream>
 #include <stdexcept>
 #include "Logger.hpp"
+#include "Register.hpp"
 
-// gets changed rn
 void Renderer::updateUniformBuffer(uint32_t currentImage)
 {
     UniformBufferObject ubo{};
@@ -222,11 +222,12 @@ void Renderer::init()
 
     /* Vertex Buffer */
     std::cout << Logger::info << "Models init" << Logger::reset;
-    Model m{"resources/teapot.obj"};
-    models.push_back(m);
-    models.push_back(m);
-    for (auto& model : models)
-        model.init();
+    std::vector<Renderable*> r = g_reg.getComponents<Renderable>();
+    for (auto& obj : r)
+    {
+        models.emplace_back(obj->model_name);
+        models.back().init();
+    }
 
     std::cout << Logger::info << "Buffer initialization" << Logger::reset;
     makeUniformBuffers();


### PR DESCRIPTION
made the rendering of objects get the transform component of each renderable, am considering adding required components to entities, so some will always be accesible from construction/addentity calls